### PR TITLE
Add kvstoremesh-ci to the list of images to cleanup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,7 @@ var (
 		"clustermesh-apiserver-ci",
 		"docker-plugin-ci",
 		"hubble-relay-ci",
+		"kvstoremesh-ci",
 		"operator-ci",
 		"operator-generic-ci",
 		"operator-azure-ci",


### PR DESCRIPTION
Related: https://github.com/cilium/cilium/pull/26083, https://github.com/cilium/cilium/pull/26106